### PR TITLE
Fix issues with zooming in/out on mobile

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -3,7 +3,7 @@
   <head>
     <title>{{ page.name }} | {{ store.name }}</title>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="{{ theme | theme_css_url }}" media="screen" rel="stylesheet" type="text/css">
     {{ head_content }}
   </head>

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Snacks",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "images": [
     {
       "variable": "logo",

--- a/source/stylesheets/cart.sass
+++ b/source/stylesheets/cart.sass
@@ -8,6 +8,7 @@
   left: 0
   overflow-y: scroll
   -webkit-overflow-scrolling: touch
+  opacity: 0
   padding-top: 100px
   padding-bottom: 100px
   position: fixed
@@ -15,6 +16,7 @@
   top: 100vh
   width: 100%
   z-index: 6
+  visibility: hidden
 
   > .wrapper
     +flexbox
@@ -27,7 +29,9 @@
       padding-top: 25px
 
   &.open
+    opacity: 1
     top: 0
+    visibility: visible
 
 .keep-shopping
   +transition(all .3s)

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -97,7 +97,7 @@ button, a.button
   cursor: pointer
   display: block
   font-family: $primary-font
-  font-size: 14px
+  font-size: 16px
   height: 75px
   letter-spacing: 2px
   line-height: 75px
@@ -181,7 +181,7 @@ button, a.button
     color: $accent-text-color
     cursor: pointer
     font-family: $primary-font
-    font-size: 14px
+    font-size: 16px
     height: 100%
     letter-spacing: 1px
     line-height: 2em
@@ -274,9 +274,11 @@ input, textarea
   font-weight: bold
   line-height: 24px
   padding: 100px 0
+  word-wrap: break-word
 
   @media screen and (max-width: $break-small)
     padding: 50px 50px 50px 0
+    max-width: 75%
 
   img
     display: block


### PR DESCRIPTION
A number of issues were occurring with zooming and on mobile browsers, one of which was causing the 'keep shopping' button to appear. This fix 1) allows zooming and scaling to happen by the user, 2) stops long store names from making the page wider than the viewport, 3) does a better job of hiding the 'keep shopping' button. Font sizes are also slightly increased to prevent unwanted zooming on mobile when focusing on inputs