### PR TITLE
fix: social links open in same tab

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -52,23 +52,23 @@
           {% if theme.twitter_url != blank or theme.facebook_url != blank or theme.instagram_url != blank or theme.tumblr_url != blank or theme.pinterest_url != blank %}
             <ul class="footer-navigation-item footer-social-links">
               {% if theme.instagram_url != blank %}
-                <li><a target="_blank" title="Instagram" href="{{ theme.instagram_url }}">Instagram</a></li>
+                <li><a title="Instagram" href="{{ theme.instagram_url }}">Instagram</a></li>
               {% endif %}
 
               {% if theme.twitter_url != blank %}
-                <li><a target="_blank" title="Twitter" href="{{ theme.twitter_url }}">Twitter</a></li>
+                <li><a title="Twitter" href="{{ theme.twitter_url }}">Twitter</a></li>
               {% endif %}
 
               {% if theme.facebook_url != blank %}
-                <li><a target="_blank" title="Facebook" href="{{ theme.facebook_url }}">Facebook</a></li>
+                <li><a title="Facebook" href="{{ theme.facebook_url }}">Facebook</a></li>
               {% endif %}
 
               {% if theme.pinterest_url != blank %}
-                <li><a target="_blank" title="Pinterest" href="{{ theme.pinterest_url }}">Pinterest</a></li>
+                <li><a title="Pinterest" href="{{ theme.pinterest_url }}">Pinterest</a></li>
               {% endif %}
 
               {% if theme.tumblr_url != blank %}
-                <li><a target="_blank" title="Tumblr" href="{{ theme.tumblr_url }}">Tumblr</a></li>
+                <li><a title="Tumblr" href="{{ theme.tumblr_url }}">Tumblr</a></li>
               {% endif %}
             </ul>
           {% endif %}

--- a/source/maintenance.html
+++ b/source/maintenance.html
@@ -21,19 +21,19 @@
           <div class="wrapper">
             <ul class="footer-navigation-item footer-social-links">
               {% if theme.instagram_url != blank %}
-                <li><a target="_blank" title="Instagram" href="{{ theme.instagram_url }}">Instagram</a></li>
-              {% endif %}            
+                <li><a title="Instagram" href="{{ theme.instagram_url }}">Instagram</a></li>
+              {% endif %}
               {% if theme.twitter_url != blank %}
-                <li><a target="_blank" title="Twitter" href="{{ theme.twitter_url }}">Twitter</a></li>
-              {% endif %}            
+                <li><a title="Twitter" href="{{ theme.twitter_url }}">Twitter</a></li>
+              {% endif %}
               {% if theme.facebook_url != blank %}
-                <li><a target="_blank" title="Facebook" href="{{ theme.facebook_url }}">Facebook</a></li>
+                <li><a title="Facebook" href="{{ theme.facebook_url }}">Facebook</a></li>
               {% endif %}
               {% if theme.pinterest_url != blank %}
-                <li><a target="_blank" title="Pinterest" href="{{ theme.pinterest_url }}">Pinterest</a></li>
+                <li><a title="Pinterest" href="{{ theme.pinterest_url }}">Pinterest</a></li>
               {% endif %}
               {% if theme.tumblr_url != blank %}
-                <li><a target="_blank" title="Tumblr" href="{{ theme.tumblr_url }}">Tumblr</a></li>
+                <li><a title="Tumblr" href="{{ theme.tumblr_url }}">Tumblr</a></li>
               {% endif %}
             </ul>
           </div>


### PR DESCRIPTION
Slightly better for accessibility. Don't bother opening social links in new tab. If apps are installed, universal/deep links will open in the native apps anyways.