### PR TITLE
chore: add data hook and page type to Layout

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -7,8 +7,8 @@
     <link href="{{ theme | theme_css_url }}" media="screen" rel="stylesheet" type="text/css">
     {{ head_content }}
   </head>
-  <body id="{{ page.permalink }}" class="{{ page.category }} {% if page.permalink != 'cart' %}{% if cart.item_count > 0 %}cart-footer{% endif %}{% endif %}">
-    <header class="header">
+  <body id="{{ page.permalink }}" class="{{ page.category }} {% if page.permalink != 'cart' %}{% if cart.item_count > 0 %}cart-footer{% endif %}{% endif %}" data-bc-page-type="{% if page.category == 'custom' %}custom{% else %}{{ page.permalink }}{% endif %}">
+    <header class="header" data-bc-hook="header">
       <div class="wrapper">
         {% if theme.logo != blank %}
           <a class="store-link" href="/" title="{{ store.name | escape }}"><img alt="{{ store.name | escape }}" src="{{ theme.images.logo.url | constrain: 600, 200 }}"></a>
@@ -35,7 +35,7 @@
         {% endif %}
       </div>
     </div>
-    <footer class="footer">
+    <footer class="footer" data-bc-hook="footer">
       <div class="wrapper">
         <div class="footer-divider"></div>
         <div class="footer-navigation">

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Snacks",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "images": [
     {
       "variable": "logo",


### PR DESCRIPTION
Allows for 3rd party apps to target key regions for adding content. In particular, key for omnisend and email partners to be able to insert content above the footer.

1. Adds `data-bc-hook` attribute to header and footer
2. Adds `data-bc-page-type` attribute to the body tag

Note: A much larger change was previously proposed but I've scaled it back to only the above 2 changes foregoing the larger change which is much more complex.
